### PR TITLE
Delay flex counters stats init for faster boot time, option 1

### DIFF
--- a/orchagent/portsorch.h
+++ b/orchagent/portsorch.h
@@ -22,6 +22,7 @@
 #define QUEUE_STAT_COUNTER_FLEX_COUNTER_GROUP "QUEUE_STAT_COUNTER"
 #define QUEUE_WATERMARK_STAT_COUNTER_FLEX_COUNTER_GROUP "QUEUE_WATERMARK_STAT_COUNTER"
 #define PG_WATERMARK_STAT_COUNTER_FLEX_COUNTER_GROUP "PG_WATERMARK_STAT_COUNTER"
+#define BOOT_TIMEOUT 30
 
 
 typedef std::vector<sai_uint32_t> PortSupportedSpeeds;
@@ -209,6 +210,11 @@ private:
 
     NotificationConsumer* m_portStatusNotificationConsumer;
 
+    // Data structure to keep all flex counters information to handle after boot has finished.
+    bool m_boot_timeout_reached;
+    SelectableTimer* m_boot_timer = nullptr;
+    vector<tuple<sai_object_id_t, enum CounterType, unordered_set<string>>> m_port_stat_list;
+
     void doTask() override;
     void doTask(Consumer &consumer);
     void doPortTask(Consumer &consumer);
@@ -218,6 +224,8 @@ private:
     void doLagMemberTask(Consumer &consumer);
 
     void doTask(NotificationConsumer &consumer);
+
+    void doTask(SelectableTimer &timer);
 
     void removePortFromLanesMap(string alias);
     void removePortFromPortListMap(sai_object_id_t port_id);


### PR DESCRIPTION
Signed-off-by: Shlomi Bitton <shlomibi@nvidia.com>

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Add a new timer on PortsOrch class to wait for boot to finish before creating flex counters objects on flex counters DB.

**Why I did it**
Creating flex counters objects on the DB will trigger 'SYNCD' to access the HW for query statistics capabilities.
This HW access takes time and will be better to finish boot before doing this (mainly for fast-reboot but good to have in general).
The flex counters are not crucial at boot time, we can delay it to the end of the boot process.

**How I verified it**
Reboot a switch and observer the flex counters DB populated after 2 minutes.

**Details if related**
